### PR TITLE
Update NixOS Wiki link

### DIFF
--- a/notes/Nix_OS_Wishlist.org
+++ b/notes/Nix_OS_Wishlist.org
@@ -8,7 +8,7 @@ Started as a small list but I guess this is also now a log of me trying to make 
 
 * Automatic Updates
 Ideally: as easy or easier than on Fedora, meaning I don't really want to have to make my own systemd service or somesuch.
-snippet from: https://nixos.wiki/wiki/Automatic_system_upgrades
+snippet from: https://wiki.nixos.org/wiki/Automatic_system_upgrades
 
 #+begin_src nix
 system.autoUpgrade = {
@@ -82,7 +82,7 @@ Search param: ==wireguard==
 *** Interesting...I'm just going to look for an example.
 Example blog post: https://alberand.com/nixos-wireguard-vpn.html
 
-Example from the NixOS wiki @ https://nixos.wiki/wiki/WireGuard:
+Example from the NixOS wiki @ https://wiki.nixos.org/wiki/WireGuard:
 **** This example uses wg-quick, but like the above blog mentions, there are options that use NetworkManager or systemd-networkd
 #+begin_src nix
 {

--- a/notes/WIL.org
+++ b/notes/WIL.org
@@ -20,7 +20,7 @@ https://wiki.nixos.org/wiki/Ubuntu_vs._NixOS
 ** How to convert Default NixOS to NixOS w/ Flakes + Practical NixOS book
 https://drakerossman.com/blog/how-to-add-home-manager-to-nixos
 ** NixOS Example Configs with Comparison Table
-https://nixos.wiki/wiki/Comparison_of_NixOS_setups
+https://wiki.nixos.org/wiki/Comparison_of_NixOS_setups
 ** Base/Starter Configs
 https://github.com/Misterio77/nix-starter-configs/blob/main/standard/nixos/configuration.nix
 


### PR DESCRIPTION
Hello there 👋!

The NixOS wiki is in the process of migrating from https://nixos.wiki to https://wiki.nixos.org.
You can find more information about it [here](https://github.com/NixOS/foundation/issues/113).

You seem to be using the old link in your repository, which is why we send you this PR.
If you feel like this is not correct or have any questions, feel free to [get in touch with us](https://github.com/NixOS/nixos-wiki-infra/issues/105).


Have a great day,

-- The NixOS Wiki-Team ❄️